### PR TITLE
Set * for ext-xdebug version and improve assertion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "~7",
         "v-dem/queasy-config": "dev-master",
         "v-dem/queasy-log": "dev-master",
-        "ext-xdebug": "^2.6.0"
+        "ext-xdebug": "*"
     },
     "suggest": {
         "queasy/config": "Configuration provider package, supports PHP (and multifile configs in this case), INI, XML and JSON (and YAML in future) formats",

--- a/tests/src/FieldTest.php
+++ b/tests/src/FieldTest.php
@@ -59,7 +59,7 @@ class FieldTest extends TestCase
     {
         $roles = $this->qdb->user_roles->id(2);
 
-        $this->assertTrue(is_array($roles));
+        $this->assertIsArray($roles);
         $this->assertEquals('Manager', $roles[0]['name']);
     }
 

--- a/tests/src/TableTest.php
+++ b/tests/src/TableTest.php
@@ -240,7 +240,7 @@ class TableTest extends TestCase
     {
         $uniqueId = $this->qdb->ids->insert();
 
-        $this->assertTrue(is_numeric($uniqueId));
+        $this->assertIsNumeric($uniqueId);
 
         $row = $this->pdo->query('SELECT * FROM `ids` WHERE `id` = ' . $uniqueId)->fetch(PDO::FETCH_ASSOC);
 
@@ -296,7 +296,7 @@ class TableTest extends TestCase
 
     public function testCount()
     {
-        $this->assertEquals(3, count($this->qdb->user_roles));
+        $this->assertCount(3, $this->qdb->user_roles);
     }
 
     public function testForeach()
@@ -313,7 +313,7 @@ class TableTest extends TestCase
         $rowsCount = 0;
         foreach ($this->qdb->users as $user) {
             $offset = array_search($user['id'], $expectedIds);
-            $this->assertTrue(is_numeric($offset));
+            $this->assertIsNumeric($offset);
             $this->assertEquals($expectedIds[$offset], $user['id']);
             $this->assertEquals($expectedEmails[$offset], $user['email']);
             $this->assertEquals($expectedPasswordHashes[$offset], $user['password_hash']);


### PR DESCRIPTION
# Changed log

- It should set the `*` version definition for `ext-xdebug` because it's not necessary to specify `ext-xdebug` version.
- Using `assertCount` to assert expected count is same as result.
- Using `assertIsArray` to assert expected type is `array`.
- Using `assertIsNumberic` to assert expected type is `numeric` type.